### PR TITLE
Fix parsing of epub3 metadata

### DIFF
--- a/NickelSeries/metadata.cc
+++ b/NickelSeries/metadata.cc
@@ -140,7 +140,7 @@ void NSMetadata::init(QXmlStreamReader &r) {
             continue;
         }
 
-        QStringRef name = r.attributes().value("name");
+        QString name = r.attributes().value("name").toString();
         if (name.startsWith("calibre:series")) {
             if (name == "calibre:series")
                 this->series[NSMetadata::calibre].first = r.attributes().value("content").toString();
@@ -161,7 +161,7 @@ void NSMetadata::init(QXmlStreamReader &r) {
             continue;
         }
 
-        name = r.attributes().value("property");
+        name = r.attributes().value("property").toString();
         if (name == "belongs-to-collection" || name == "collection-type" || name == "group-position") {
             QString id = r.attributes().value("refines").startsWith("#")
                 ? r.attributes().value("refines").mid(1).toString()


### PR DESCRIPTION
Use a QString for 'name' instead of a QStringRef to ensure its value
doesn't change even after calling QXmlStreamReader::readElementText(),
which may update the content of the internal buffer that 'name' was
referring to.  Without this, later comparisons against 'name' may fail
as it no longer points to the value of the property attribute, but
rather a substring of the <meta> element's text.
